### PR TITLE
Docs and editor config updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*.clar]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.{ts,js,json,md}]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,37 @@
+# Development Guide
+
+Overview
+
+This document explains how to work on the Smart-Waste-Management-System locally, validate contracts, and run tests.
+
+Requirements
+
+- Clarinet 3.x
+- Node.js LTS and npm
+- Git + GitHub CLI (gh)
+
+Contracts
+
+- contracts/smart-bin-monitoring.clar
+- contracts/eco-rewards-token-system.clar
+
+Both are independent (no traits, no cross-contract calls).
+
+Validation
+
+- Compile/type-check all contracts:
+  clarinet check
+
+Testing
+
+1) Install dependencies:
+  npm install
+
+2) Run vitest with coverage and costs:
+  npm run test:report
+
+Notes
+
+- .editorconfig enforces LF endings for .clar files; if you edit on Windows, ensure your editor respects .editorconfig to avoid CRLF issues.
+- Initialize admin in tests by calling set-admin from the deployer before any privileged actions.
+- Use development branch for ongoing work; open PRs targeting main.


### PR DESCRIPTION
Overview

This PR adds:
- .editorconfig to enforce LF endings and UTF-8 for .clar files
- docs/DEVELOPMENT.md with validation and testing instructions

Rationale

- Prevent CRLF parsing issues in Clarity files on Windows environments
- Provide a concise developer workflow for clarinet check and tests

Verification

- clarinet check passes locally
- No functional changes to contracts